### PR TITLE
restore preset and bank _after_ soundfont

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -260,12 +260,6 @@ void JuicySFAudioProcessor::setStateInformation (const void* data, int sizeInByt
     if (xmlState.get() != nullptr) {
         // make sure that it's actually our type of XML object..
         if (xmlState->hasTagName(valueTreeState.state.getType())) {
-            XmlElement* params{xmlState->getChildByName("params")};
-            if (params)
-                for (auto* param : getParameters())
-                    if (auto* p = dynamic_cast<AudioProcessorParameterWithID*>(param))
-                        p->setValue(static_cast<float>(params->getDoubleAttribute(p->paramID, p->getValue())));
-            
             {
                 XmlElement* xmlElement{xmlState->getChildByName("soundFont")};
                 if (xmlElement) {
@@ -285,6 +279,14 @@ void JuicySFAudioProcessor::setStateInformation (const void* data, int sizeInByt
                     {
                         Value value{tree.getPropertyAsValue("height", nullptr)};
                         value = xmlElement->getIntAttribute("height", value.getValue());
+                    }
+                }
+            }
+            XmlElement* params{xmlState->getChildByName("params")};
+            if (params) {
+                for (auto* param : getParameters()) {
+                    if (auto* p = dynamic_cast<AudioProcessorParameterWithID*>(param)) {
+                        p->setValueNotifyingHost(static_cast<float>(params->getDoubleAttribute(p->paramID, p->getValue())));
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/Birch-san/juicysfplugin/issues/11

Also stop attempting any restoration of parameters during initialise sequence, since it seems to run so early that we could only ever hope to see defaults there.