### PR TITLE
Guard against out-of-bounds

### DIFF
--- a/Source/TableComponent.cpp
+++ b/Source/TableComponent.cpp
@@ -175,9 +175,11 @@ void TableComponent::paintCell (
     g.setColour (getLookAndFeel().findColour (ListBox::textColourId));
     g.setFont (font);
 
-    TableRow& row{rows[rowNumber]};
-    String text{row.getStringContents(columnId)};
-    g.drawText (text, 2, 0, width - 4, height, Justification::centredLeft, true);
+	if (rowNumber < rows.size()) {
+		TableRow& row{ rows[rowNumber] };
+		String text{ row.getStringContents(columnId) };
+		g.drawText(text, 2, 0, width - 4, height, Justification::centredLeft, true);
+	}
 
     g.setColour (getLookAndFeel().findColour (ListBox::backgroundColourId));
     g.fillRect (width - 1, 0, 1, height);


### PR DESCRIPTION
…when looking up what text to write into each row of preset table (which for some reason didn't cause any problems on macOS)