### PR TITLE
feat(limited vst settings portablilty support)

### DIFF
--- a/Source/FilePicker.cpp
+++ b/Source/FilePicker.cpp
@@ -41,7 +41,10 @@ FilePicker::FilePicker(
     setOpaque (true);
 
     // setDisplayedFilePath(fluidSynthModel.getCurrentSoundFontAbsPath());
-    setDisplayedFilePath(valueTreeState.state.getChildWithName("soundFont").getProperty("path", ""));
+    String soundFontPath = valueTreeState.state.getChildWithName("soundFont").getProperty("path", "");
+        DBG("######## valueTreePropertyChanged getAbsolutePath("+soundFontPath+")="+Util::getAbsolutePath(soundFontPath));
+    soundFontPath = Util::getAbsolutePath(soundFontPath);
+    setDisplayedFilePath(soundFontPath);
 
     addAndMakeVisible (fileChooser);
     fileChooser.addListener (this);
@@ -91,8 +94,11 @@ void FilePicker::filenameComponentChanged (FilenameComponent*) {
 #endif
     // currentPath = fileChooser.getCurrentFile().getFullPathName();
     // fluidSynthModel.onFileNameChanged(fileChooser.getCurrentFile().getFullPathName(), -1, -1);
+    String path = fileChooser.getCurrentFile().getFullPathName();
+        DBG("######## filenameComponentChanged getRelativeToHomePath("+path+")="+ Util::getRelativeToHomePath(path));
+    path = Util::getRelativeToHomePath(path);
     Value value{valueTreeState.state.getChildWithName("soundFont").getPropertyAsValue("path", nullptr)};
-    value.setValue(fileChooser.getCurrentFile().getFullPathName());
+    value.setValue(path);
 //    value = fileChooser.getCurrentFile().getFullPathName();
 }
 
@@ -102,8 +108,10 @@ void FilePicker::valueTreePropertyChanged(ValueTree& treeWhosePropertyHasChanged
     // if (&treeWhosePropertyHasChanged == &valueTree) {
         if (property == StringRef("path")) {
             String soundFontPath = treeWhosePropertyHasChanged.getProperty("path", "");
+                DBG("######## valueTreePropertyChanged getAbsolutePath("+soundFontPath+")="+Util::getAbsolutePath(soundFontPath));
+            soundFontPath = Util::getAbsolutePath(soundFontPath);
             DEBUG_PRINT(soundFontPath);
-            setDisplayedFilePath(soundFontPath);
+            // setDisplayedFilePath(soundFontPath);
             // if (soundFontPath.isNotEmpty()) {
             //     loadFont(soundFontPath);
             // }
@@ -112,10 +120,12 @@ void FilePicker::valueTreePropertyChanged(ValueTree& treeWhosePropertyHasChanged
 }
 
 void FilePicker::setDisplayedFilePath(const String& path) {
-     if (!shouldChangeDisplayedFilePath(path)) {
-         return;
-     }
+    if (!shouldChangeDisplayedFilePath(path)) {
+        return;
+    }
     // currentPath = path;
+
+    DBG("######## setDisplayedFilePath "+path);
     fileChooser.setCurrentFile(File(path), true, dontSendNotification);
 }
 
@@ -123,6 +133,7 @@ bool FilePicker::shouldChangeDisplayedFilePath(const String &path) {
     if (path.isEmpty()) {
         return false;
     }
+    DBG("######## shouldChangeDisplayedFilePath "+path+" VS "+ currentPath);
     if (path == currentPath) {
         return false;
     }

--- a/Source/FluidSynthModel.cpp
+++ b/Source/FluidSynthModel.cpp
@@ -237,7 +237,8 @@ void FluidSynthModel::valueTreePropertyChanged(ValueTree& treeWhosePropertyHasCh
             StringRef path {String::fromCFString(cfPath.get())};
             if (path.isNotEmpty()) {
                 CFURLStartAccessingSecurityScopedResource(cfURL.get());
-                unloadAndLoadFont(path);
+                    DBG("######## getAbsolutePath("+path+")="+ Util::getAbsolutePath(path));
+                unloadAndLoadFont(Util::getAbsolutePath(path));
                 CFURLStopAccessingSecurityScopedResource(cfURL.get());
             }
         }
@@ -245,7 +246,8 @@ void FluidSynthModel::valueTreePropertyChanged(ValueTree& treeWhosePropertyHasCh
         if (property == StringRef("path")) {
             String soundFontPath = treeWhosePropertyHasChanged.getProperty("path", "");
             if (soundFontPath.isNotEmpty()) {
-                unloadAndLoadFont(soundFontPath);
+                    DBG("######## getAbsolutePath("+soundFontPath+")="+ Util::getAbsolutePath(soundFontPath));
+                unloadAndLoadFont(Util::getAbsolutePath(soundFontPath));
             }
         }
 #endif

--- a/Source/Util.h
+++ b/Source/Util.h
@@ -11,6 +11,46 @@
 #endif
 
 namespace Util {
+  inline String getHomeDirectory() {
+    static String homeDirectory = []() -> String {
+    #if JUCE_WINDOWS
+      const char* homeDir = std::getenv("USERPROFILE");
+    #else
+      const char* homeDir = std::getenv("HOME");
+    #endif
+      return homeDir != nullptr ? String(homeDir) : String();
+    }();
+
+    return homeDirectory;
+  }
+
+  inline String getAbsolutePath(const String& relativePath) {
+    String homeDir = getHomeDirectory();
+    String normalizedRelativePath = relativePath.replace("~", homeDir);
+    #if JUCE_WINDOWS
+    #else
+      normalizedRelativePath = normalizedRelativePath.replace("\\", "/");
+    #endif
+    File absoluteFile(normalizedRelativePath);
+    return absoluteFile.getFullPathName();
+  }
+
+  inline String getRelativeToHomePath(const String& absolutePath) {
+    String homeDir = getHomeDirectory();
+
+    if (absolutePath.startsWith(homeDir)) {
+      String resultPath = "~/" + absolutePath.substring(homeDir.length() + 1);
+      #if JUCE_WINDOWS
+        resultPath = resultPath.replace("\\", "/");
+      #else
+      #endif
+      
+      return resultPath;
+    }
+
+    return absolutePath;
+  }
+  
   inline int compare(int a, int b) {
     if (a > b) return 1;
     if (a == b) return 0;


### PR DESCRIPTION
~ as relative home path for sf2 file on win+mac

windows paths like c:\Users\Whoever\somePath\myFont.sf2 or
mac paths like /Users/Whoever/somePath/myFont.sf2 or will be translated and saved in the vst settings chunk of a project as ~/somePath/myFont.sf2
so if you place or SYMLINK needed soundfonts to some folder for current user, when you will open saved project (for example Reaper's project) on different computer, no matter windows or mac,
you will not have to endure the pain of providing the path for missing .sf2 each time over and over again.

